### PR TITLE
Forsøker å fikse prod-gcp ved å disable "istio"

### DIFF
--- a/.deploy/prod-gcp-teamfamilie.yaml
+++ b/.deploy/prod-gcp-teamfamilie.yaml
@@ -32,7 +32,7 @@ spec:
     enabled: true # if true the pod will be scraped for metrics by prometheus
     path: /internal/metrics/prometheus # Path to prometheus-metrics
   istio: # Optional.
-    enabled: true # Optional. When true, envoy-proxy sidecar will be injected into pod and https urls envvars will be rewritten
+    enabled: false # Optional. When true, envoy-proxy sidecar will be injected into pod and https urls envvars will be rewritten
   resources: # Optional. See: http://kubernetes.io/docs/user-guide/compute-resources/
     limits:
       cpu: "1000m" # app will have its cpu usage throttled if exceeding this limit


### PR DESCRIPTION
...som er den eneste config-verdien som skiller oppsettet til prod-gcp fra oppsettene til dev-gcp og prod-fss