### PR TITLE
Kun vis tom-dato når finnes

### DIFF
--- a/content/templates/submaler/du-får-seksjon/template.hbs
+++ b/content/templates/submaler/du-får-seksjon/template.hbs
@@ -1,6 +1,6 @@
 {{#if duFaar.length}}
 {{#each duFaar}}
-Fra {{fom}} og til {{#if tom}} og med {{tom}}{{/if}} får du:
+Fra {{fom}}{{#if tom}} og til og med {{tom}}{{/if}} får du:
 <ul>
     <li>
         {{belop}} kroner i måneden for {{antallBarn}} barn født {{barnasFodselsdatoer}}.


### PR DESCRIPTION
![Skjermbilde 2020-10-02 kl  12 36 36](https://user-images.githubusercontent.com/5719550/94914785-f7e79480-04ab-11eb-9c99-40ba45a4ad2c.png)

I brev skal ikke perioder som begynner i framtiden vises, og vi viser heller ikke sluttdato på løpende. Se 👆 .

Logikk for bestemmelse av tom: https://github.com/navikt/familie-ba-sak/commit/5fe751f1f8abeca8e2312d4e634b17a5bc09b766#diff-8c84f7833a2b108843343c22e8d9ca4fR145
