### PR TITLE
Update ingress configuration

### DIFF
--- a/.deploy/prod-fss-default.yaml
+++ b/.deploy/prod-fss-default.yaml
@@ -41,8 +41,7 @@ spec:
       cpu: "100m"
       memory: "1024Mi"
   ingresses: # Optional. List of ingress URLs that will route HTTP traffic to the application.
-    - "https://familie-ba-dokgen.intern.nav.no/"
-    - "https://familie-ba-dokgen.prod-gcp.nais.io/"
+    - "https://familie-ba-dokgen.nais.adeo.no/"
   logformat: accesslog # Optional. The format of the logs from the container if the logs should be handled differently than plain text or json
   logtransform: dns_loglevel # Optional. The transformation of the logs, if they should be handled differently than plain text or json
   webproxy: false # Optional. Expose web proxy configuration to the application using the HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment variables.


### PR DESCRIPTION
According to nais documentation, application for internal users should use "dev.intern.nav.no" and services should use "dev-gcp.nais.io" for dev, while use "intern.nav.no" and "prod-gcp.nais.io" respectively for prod.
I am not sure if dokgen is sort of application or service, so I added both ingresses.