### PR TITLE
(feat) Kun vis seksjon for separert-enke-skilt hvis søker er registrert gift

### DIFF
--- a/content/templates/soknad-utvidet/din-livssituasjon.hbs
+++ b/content/templates/soknad-utvidet/din-livssituasjon.hbs
@@ -5,7 +5,7 @@
 <h5>{{spørsmål.årsak.label}}</h5>
 <p>{{spørsmål.årsak.verdi}}</p>
 </td>
-{{#eq sivilstand.verdi "GIFT"}}
+{{#eq ../søker.sivilstand.verdi "GIFT"}}
 <td>
 <h5>{{spørsmål.separertEnkeSkilt.label}}</h5>
 <p>{{spørsmål.separertEnkeSkilt.verdi}}</p>

--- a/content/templates/soknad-utvidet/uncompiled/din-livssituasjon.hbs
+++ b/content/templates/soknad-utvidet/uncompiled/din-livssituasjon.hbs
@@ -5,7 +5,7 @@
             <h5>{{spørsmål.årsak.label}}</h5>
             <p>{{spørsmål.årsak.verdi}}</p>
         </td>
-        {{#eq sivilstand.verdi "GIFT"}}
+        {{#eq ../søker.sivilstand.verdi "GIFT"}}
             <td>
                 <h5>{{spørsmål.separertEnkeSkilt.label}}</h5>
                 <p>{{spørsmål.separertEnkeSkilt.verdi}}</p>


### PR DESCRIPTION
Disse spørsmålene besvares kun i frontend hvis søker har sivilstand GIFT, derfor trenger vi ikke å rendre dem hvis søker har en annen sivilstand, da de vil være null

Før:
![stand-check-before](https://user-images.githubusercontent.com/77009351/131655611-7d9d49ed-4be7-4113-a956-8be949973602.png)

Etter ikke gift:
![stand-check-after](https://user-images.githubusercontent.com/77009351/131655616-65eb58fa-45a0-416f-8b60-35a6477de202.png)

Etter gift:
![stand-check-gift-after](https://user-images.githubusercontent.com/77009351/131655796-ae379417-1a88-44c3-9d96-eccfd687d515.png)

