### PR TITLE
Feature/legg til spm bor pa denne adressen

### DIFF
--- a/content/templates/soknad/omdeg.hbs
+++ b/content/templates/soknad/omdeg.hbs
@@ -24,7 +24,6 @@
 {{/with}}
 </td>
 </tr>
-<!-- Bare inkluder hvis adresse er annet enn tomt object {} -->
 {{#if adresse.verdi.poststed}}
 <tr>
 {{> soknad/ja-nei spørsmål.borPåRegistrertAdresse}}

--- a/content/templates/soknad/uncompiled/omdeg.hbs
+++ b/content/templates/soknad/uncompiled/omdeg.hbs
@@ -24,7 +24,6 @@
                 {{/with}}
             </td>
         </tr>
-<!-- Bare inkluder hvis adresse er annet enn tomt object {} -->
         {{#if adresse.verdi.poststed}}
             <tr>
                 {{> soknad/ja-nei spørsmål.borPåRegistrertAdresse}}


### PR DESCRIPTION
Legger til spørsmål "Bor du på denne adressen?"

Legger kun til spørsmålet hvis søker.adresse.poststed eksisterer. Antar altså at alle typer adresser har poststed, og at hvis poststed er null, så er det fordi bruker har adressesperre. Ikke sikker på om antagelsen er riktig.

Testet og verifisert at det blir riktig med forskjellige adressetyper (vha Dolly)


Screenshots:

nåværende pdf ordinær
<img width="793" alt="pdf-bor-adresse-previouse" src="https://user-images.githubusercontent.com/17552002/133399496-d5c3ed73-ecea-49e7-b6ee-f8e3e991252e.png">

nåværende pdf utvidet
<img width="799" alt="pdf-bor-adresse-utvidet-previous" src="https://user-images.githubusercontent.com/17552002/133399536-ac7d07d7-0a3b-4cd0-9357-20774328dec6.png">

implement spørmsål, ordinær
<img width="608" alt="pdf-bor-adresse-updated-proposal" src="https://user-images.githubusercontent.com/17552002/133399595-0301218e-1b0e-4b02-8506-bf06d5084f92.png">

implementert spørsmål utvidet
<img width="408" alt="pdf-bor-adresse-utvidet-updated-proposal" src="https://user-images.githubusercontent.com/17552002/133399709-52d6d122-1214-4a78-b4d5-21138aed685b.png">


implementert spørsmål ordinær, matrikkeladresse
<img width="796" alt="pdf-bor-spm-matrikkeladresse" src="https://user-images.githubusercontent.com/17552002/133399774-162e84b2-6d97-4f10-b60f-d10f22f51e4c.png">

