### PR TITLE
Styling på seksjonsundertittel

### DIFF
--- a/content/formats/pdf/style.css
+++ b/content/formats/pdf/style.css
@@ -355,6 +355,13 @@ ul {
     margin-bottom: 1.33rem;
 }
 
+.soknad-seksjon-undertittel {
+    color: #262626;
+    font-weight: 600;
+    margin-bottom: 1.25rem;
+    font-size: 1.125rem;
+}
+
 .soknad-sporsmal {
     font-weight: 600;
 }

--- a/content/templates/soknad/eos-for-barn.hbs
+++ b/content/templates/soknad/eos-for-barn.hbs
@@ -23,7 +23,7 @@
 
 {{#if andreForelder }}
 {{#unless andreForelder.kanIkkeGiOpplysninger }}
-<p>{{ @root.teksterUtenomSpørsmål.[pdf.andreforelder.seksjonstittel]}}</p>
+<h3 class="soknad-seksjon-undertittel">{{ @root.teksterUtenomSpørsmål.[pdf.andreforelder.seksjonstittel]}}</h3>
 {{/unless}}
 {{#each andreForelder.idNummer as | idNummer | }}
 {{> soknad/sporsmal-med-svar felt=idNummer.verdi.idNummer svar-type="normal" }}

--- a/content/templates/soknad/uncompiled/eos-for-barn.hbs
+++ b/content/templates/soknad/uncompiled/eos-for-barn.hbs
@@ -23,7 +23,7 @@
 
         {{#if andreForelder }}
             {{#unless andreForelder.kanIkkeGiOpplysninger }}
-                <p>{{ @root.teksterUtenomSpørsmål.[pdf.andreforelder.seksjonstittel]}}</p>
+                <h3 class="soknad-seksjon-undertittel">{{ @root.teksterUtenomSpørsmål.[pdf.andreforelder.seksjonstittel]}}</h3>
             {{/unless}}
             {{#each andreForelder.idNummer as | idNummer | }}
                 {{> soknad/sporsmal-med-svar felt=idNummer.verdi.idNummer svar-type="normal" }}


### PR DESCRIPTION
Fikser styling på "Andre forelder" som er en seksjonsundertittel:

<img width="847" alt="Screenshot 2022-04-19 at 10 03 32" src="https://user-images.githubusercontent.com/8656966/163982704-940b59fe-ca80-4dcc-a7b3-18adeba09909.png">
