### PR TITLE
Fjernet jobberPåBåt feltet fra barnetrygd-malene

### DIFF
--- a/content/templates/soknad-utvidet/din-livssituasjon-utvidet.hbs
+++ b/content/templates/soknad-utvidet/din-livssituasjon-utvidet.hbs
@@ -41,7 +41,6 @@
 {{> soknad/sporsmal-med-svar felt=erAsylsøker svar-type="ja-nei" }}
 
 {{> soknad/sporsmal-med-svar felt=arbeidIUtlandet svar-type="ja-nei" }}
-{{> soknad/sporsmal-med-svar felt=jobberPåBåt svar-type="ja-nei" }}
 {{#each arbeidsperioderUtland as | arbeidsperiode | }}
 <p class="periode-tittel">{{label}}</p>
 {{#with verdi}}

--- a/content/templates/soknad-utvidet/uncompiled/din-livssituasjon-utvidet.hbs
+++ b/content/templates/soknad-utvidet/uncompiled/din-livssituasjon-utvidet.hbs
@@ -41,7 +41,6 @@
         {{> soknad/sporsmal-med-svar felt=erAsylsøker svar-type="ja-nei" }}
 
         {{> soknad/sporsmal-med-svar felt=arbeidIUtlandet svar-type="ja-nei" }}
-        {{> soknad/sporsmal-med-svar felt=jobberPåBåt svar-type="ja-nei" }}
         {{#each arbeidsperioderUtland as | arbeidsperiode | }}
             <p class="periode-tittel">{{label}}</p>
             {{#with verdi}}

--- a/content/templates/soknad/din-livssituasjon.hbs
+++ b/content/templates/soknad/din-livssituasjon.hbs
@@ -14,7 +14,6 @@
 {{> soknad/sporsmal-med-svar felt=erAsylsøker svar-type="ja-nei" }}
 
 {{> soknad/sporsmal-med-svar felt=arbeidIUtlandet svar-type="ja-nei" }}
-{{> soknad/sporsmal-med-svar felt=jobberPåBåt svar-type="ja-nei" }}
 {{#each arbeidsperioderUtland as | arbeidsperiode | }}
 <p class="periode-tittel">{{label}}</p>
 {{#with verdi}}

--- a/content/templates/soknad/uncompiled/din-livssituasjon.hbs
+++ b/content/templates/soknad/uncompiled/din-livssituasjon.hbs
@@ -14,7 +14,6 @@
         {{> soknad/sporsmal-med-svar felt=erAsylsøker svar-type="ja-nei" }}
 
         {{> soknad/sporsmal-med-svar felt=arbeidIUtlandet svar-type="ja-nei" }}
-        {{> soknad/sporsmal-med-svar felt=jobberPåBåt svar-type="ja-nei" }}
         {{#each arbeidsperioderUtland as | arbeidsperiode | }}
             <p class="periode-tittel">{{label}}</p>
             {{#with verdi}}


### PR DESCRIPTION
`jobberPåBåt` er nå erstattet med `arbeidIUtlandet` i både dokgen og i ba-soknad så nå er det trygt å fjerne det redundante feltet `jobberPåBåt` fra barnetrygd-malene.