### PR TITLE
Ikke ha dependabot-oppsett for maven. Legg til dependabot-oppsett for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,6 @@
 version: 2
-registries:
-  familie-felles:
-    type: maven-repository
-    url: https://maven.pkg.github.com/navikt/maven-release
-    username: x-access-token
-    password: "${{secrets.READER_TOKEN}}"
-
 updates:
-  - package-ecosystem: maven
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    registries:
-      - familie-felles
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+      interval: "weekly"


### PR DESCRIPTION
Dette prosjektet er ikke et maven-prosjekt og bør derfor ikke ha dependabot-oppsett for maven.

Vi bruker github-actions, så legger til dependabot-oppsett for det. 